### PR TITLE
Add tests and focused library entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,37 @@ frame = compute_returns_for_directory(
 )
 ```
 
+If you want to split the workflow up yourself, the package also exposes a few focused entry points:
+
+```python
+from pathlib import Path
+
+from wsj_stock_downloader import (
+    download_ticker_lists,
+    load_ticker_lists,
+    write_returns_outputs,
+)
+
+ticker_lists = load_ticker_lists(Path("tickers"))
+download_results = download_ticker_lists(ticker_lists, data_dir=Path("data"), workers=4)
+written_files = write_returns_outputs(
+    data_dir=Path("data"),
+    returns_dir=Path("returns"),
+    start_date="2010-01-01",
+    end_date="2023-12-31",
+)
+```
+
+## Running tests
+
+The test suite uses Python's built-in `unittest` runner, so there is no extra test dependency to install.
+
+After installing the package dependencies, run:
+
+```bash
+python -m unittest discover -s tests
+```
+
 ## Notes
 
 - Ticker list files are just organizational buckets. There is no portfolio weighting or aggregation logic per list.

--- a/src/wsj_stock_downloader/__init__.py
+++ b/src/wsj_stock_downloader/__init__.py
@@ -1,10 +1,19 @@
 """Public API for the wsj_stock_downloader package."""
 
-from .returns import compute_returns_for_directory, compute_returns_frame
+from .downloader import download_ticker_lists
+from .returns import (
+    compute_returns_for_directory,
+    compute_returns_frame,
+    write_returns_outputs,
+)
+from .tickers import load_ticker_lists
 from .workflow import run_pipeline
 
 __all__ = [
+    "download_ticker_lists",
     "compute_returns_for_directory",
     "compute_returns_frame",
+    "load_ticker_lists",
     "run_pipeline",
+    "write_returns_outputs",
 ]

--- a/src/wsj_stock_downloader/downloader.py
+++ b/src/wsj_stock_downloader/downloader.py
@@ -71,3 +71,17 @@ def download_all(tasks: list[DownloadTask], workers: int = 8) -> list[DownloadRe
     max_workers = max(1, min(workers, len(tasks)))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return list(executor.map(download_one, tasks))
+
+
+def download_ticker_lists(
+    ticker_lists: dict[str, list[str]],
+    data_dir: Path,
+    workers: int = 8,
+) -> list[DownloadResult]:
+    """Download CSVs for the provided ticker lists into ``data_dir``.
+
+    This is the reusable library-level entry point for callers who want to
+    control ticker discovery themselves without running the full pipeline.
+    """
+    tasks = plan_downloads(ticker_lists, data_dir)
+    return download_all(tasks, workers=workers)

--- a/src/wsj_stock_downloader/workflow.py
+++ b/src/wsj_stock_downloader/workflow.py
@@ -6,7 +6,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
-from .downloader import download_all, plan_downloads
+from .downloader import download_ticker_lists
 from .returns import write_returns_outputs
 from .tickers import load_ticker_lists
 
@@ -43,8 +43,7 @@ def run_pipeline(
         returns_dir.mkdir(parents=True, exist_ok=True)
 
     ticker_lists = load_ticker_lists(tickers_dir)
-    tasks = plan_downloads(ticker_lists, data_dir)
-    download_results = download_all(tasks, workers=workers)
+    download_results = download_ticker_lists(ticker_lists, data_dir, workers=workers)
     written_files = write_returns_outputs(
         data_dir=data_dir,
         returns_dir=returns_dir,

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -1,0 +1,75 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from wsj_stock_downloader import compute_returns_for_directory, write_returns_outputs
+
+
+CSV_CONTENT = """Date,Open,High,Low,Close,Volume
+01/03/24,100,100,100,100,10
+01/04/24,110,110,110,110,10
+01/05/24,121,121,121,121,10
+"""
+
+
+class ReturnsTests(unittest.TestCase):
+    def test_daily_returns_are_computed_from_sorted_dates(self):
+        with TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir) / "data" / "example"
+            data_dir.mkdir(parents=True)
+            (data_dir / "AAPL.csv").write_text(CSV_CONTENT)
+
+            frame = compute_returns_for_directory(
+                data_dir=data_dir,
+                start_date="2024-01-03",
+                end_date="2024-01-05",
+                returns_type="daily",
+            )
+
+            self.assertListEqual(list(frame.columns), ["AAPL"])
+            self.assertAlmostEqual(frame.loc["2024-01-03", "AAPL"], 0.0)
+            self.assertAlmostEqual(frame.loc["2024-01-04", "AAPL"], 0.10)
+            self.assertAlmostEqual(frame.loc["2024-01-05", "AAPL"], 0.10)
+
+    def test_cumulative_returns_start_at_one(self):
+        with TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir) / "data" / "example"
+            data_dir.mkdir(parents=True)
+            (data_dir / "AAPL.csv").write_text(CSV_CONTENT)
+
+            frame = compute_returns_for_directory(
+                data_dir=data_dir,
+                start_date="2024-01-03",
+                end_date="2024-01-05",
+                returns_type="cumulative",
+            )
+
+            self.assertAlmostEqual(frame.loc["2024-01-03", "AAPL"], 1.0)
+            self.assertAlmostEqual(frame.loc["2024-01-04", "AAPL"], 1.1)
+            self.assertAlmostEqual(frame.loc["2024-01-05", "AAPL"], 1.21)
+
+    def test_write_returns_outputs_writes_per_list_and_combined_files(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            first_dir = root / "data" / "growth"
+            second_dir = root / "data" / "value"
+            first_dir.mkdir(parents=True)
+            second_dir.mkdir(parents=True)
+
+            (first_dir / "AAPL.csv").write_text(CSV_CONTENT)
+            (second_dir / "MSFT.csv").write_text(CSV_CONTENT)
+
+            written_files = write_returns_outputs(
+                data_dir=root / "data",
+                returns_dir=root / "returns",
+                start_date="2024-01-03",
+                end_date="2024-01-05",
+                returns_type="daily",
+            )
+
+            written_names = sorted(path.name for path in written_files)
+            self.assertEqual(written_names, ["all.csv", "growth.csv", "value.csv"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tickers.py
+++ b/tests/test_tickers.py
@@ -1,0 +1,31 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from wsj_stock_downloader import load_ticker_lists
+
+
+class TickerLoadingTests(unittest.TestCase):
+    def test_load_ticker_lists_ignores_comments_and_blank_lines(self):
+        with TemporaryDirectory() as tmp_dir:
+            tickers_dir = Path(tmp_dir) / "tickers"
+            tickers_dir.mkdir()
+            (tickers_dir / "example.txt").write_text(
+                "# comment\n\nAAPL\nMSFT\nindex/SPX\n"
+            )
+
+            ticker_lists = load_ticker_lists(tickers_dir)
+
+            self.assertEqual(
+                ticker_lists,
+                {"example": ["AAPL", "MSFT", "index/SPX"]},
+            )
+
+    def test_load_ticker_lists_requires_existing_directory(self):
+        with TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(FileNotFoundError):
+                load_ticker_lists(Path(tmp_dir) / "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a lightweight unittest suite for ticker parsing and returns generation
- expose focused public entry points for loading tickers, downloading CSVs, and writing returns outputs
- document the split workflow and how to run tests

## Testing
- PYTHONPATH=src python3 -m unittest discover -s tests
- PYTHONPATH=src python3 -c "from wsj_stock_downloader import run_pipeline, compute_returns_for_directory, load_ticker_lists, download_ticker_lists, write_returns_outputs; print(all(callable(x) for x in [run_pipeline, compute_returns_for_directory, load_ticker_lists, download_ticker_lists, write_returns_outputs]))"